### PR TITLE
Extract properties outputs for artifacts

### DIFF
--- a/.github/workflows/docker_build_push.yaml
+++ b/.github/workflows/docker_build_push.yaml
@@ -1,0 +1,45 @@
+name: Build and Push Docker Images
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        azure_cli_version: [2.68.0]  # Full semver versions
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract major.minor version and determine latest
+        id: version_processing
+        run: |
+          # Extract major.minor version (e.g., 1.2.3 -> 1.2)
+          VERSION="${{ matrix.azure_cli_version }}"
+          MAJOR_MINOR=$(echo "$VERSION" | awk -F. '{print $1"."$2}')
+          echo "MAJOR_MINOR_VERSION=$MAJOR_MINOR" >> $GITHUB_ENV
+
+          # Prepare a sorted list to determine the latest version
+          versions=($(echo "${{ join(matrix.azure_cli_version, ' ') }}" | tr ' ' '\n' | sort -V))
+          latest_full_version=${versions[-1]}
+          latest_major_minor=$(echo "$latest_full_version" | awk -F. '{print $1"."$2}')
+
+          echo "LATEST_MAJOR_MINOR_VERSION=$latest_major_minor" >> $GITHUB_ENV
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.PUBLIC_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.PUBLIC_DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: massdrivercloud/provisioner-bicep:${{ env.MAJOR_MINOR_VERSION }}${{ env.MAJOR_MINOR_VERSION == env.LATEST_MAJOR_MINOR_VERSION && ',massdrivercloud/provisioner-bicep:latest' || '' }}
+          build-args: AZURE_CLI_VERSION=${{ matrix.azure_cli_version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,7 +94,7 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
     echo "Deploying bundle"
     az deployment group create --mode Complete --name "$resource_group-$MASSDRIVER_STEP_PATH" --resource-group "$resource_group" --template-file template.bicep --parameters @params.json --parameters @connections.json | tee outputs.json
 
-    jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > artifact_inputs.json
+    jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4].properties.outputs}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > artifact_inputs.json
     for artifact_file in artifact_*.jq; do
       [ -f "$artifact_file" ] || break
       field=$(echo "$artifact_file" | sed 's/^artifact_\(.*\).jq$/\1/')


### PR DESCRIPTION
Instead of passing the entire bicep output, extract out the `.properties.outputs` block, and use that as the `outputs` field in the artifact inputs.