### PR TITLE
update versions and improve script

### DIFF
--- a/.github/workflows/docker_build_push.yaml
+++ b/.github/workflows/docker_build_push.yaml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 1
       matrix:
         include: # Full semver versions
-          - azure_cli_version: 2.81.0
+          - azure_cli_version: 2.86.0
             is_latest: true
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG CHECKOV_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl unzip make jq gnupg && \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl unzip jq gnupg && \
     curl -s https://api.github.com/repos/massdriver-cloud/xo/releases/latest | jq -r '.assets[] | select(.name | contains("linux-amd64")) | .browser_download_url' | xargs curl -sSL -o xo.tar.gz && tar -xvf xo.tar.gz -C /tmp && mv /tmp/xo /usr/local/bin/ && rm xo.tar.gz && \
     curl -sSL https://github.com/bridgecrewio/checkov/releases/download/${CHECKOV_VERSION}/checkov_linux_X86_64.zip -o checkov.zip && unzip checkov.zip && mv dist/checkov /usr/local/bin/ && rm -rf checkov.zip dist && \
     curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft.gpg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,25 @@
-ARG AZURE_CLI_VERSION=2.75.0
-ARG CHECKOV_VERSION=3.2.268
-ARG OPA_VERSION=0.69.0
-ARG RUN_IMG=debian:12.7-slim
+ARG AZURE_CLI_VERSION=2.86.0
+ARG CHECKOV_VERSION=3.2.530
+ARG RUN_IMG=debian:13.5-slim
 ARG USER=massdriver
 ARG UID=10001
 
 FROM ${RUN_IMG} AS build
 ARG AZURE_CLI_VERSION
 ARG CHECKOV_VERSION
-ARG OPA_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y curl unzip make jq apt-transport-https gnupg lsb-release && \
-    curl -s https://api.github.com/repos/massdriver-cloud/xo/releases/latest | jq -r '.assets[] | select(.name | contains("linux-amd64")) | .browser_download_url' | xargs curl -sSL -o xo.tar.gz && tar -xvf xo.tar.gz -C /tmp && mv /tmp/xo /usr/local/bin/ && rm *.tar.gz && \
-    curl -sSL https://openpolicyagent.org/downloads/v${OPA_VERSION}/opa_linux_amd64_static > /usr/local/bin/opa && chmod a+x /usr/local/bin/opa && \
-    curl -sSL https://github.com/bridgecrewio/checkov/releases/download/${CHECKOV_VERSION}/checkov_linux_X86_64.zip > checkov.zip && unzip checkov.zip && mv dist/checkov /usr/local/bin/ && rm *.zip && \
-    curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
-    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list && \
-    apt update && \
-    if [ "$AZ_CLI_VERSION" = "latest" ]; then \
-        apt install -y azure-cli; \
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl unzip make jq gnupg && \
+    curl -s https://api.github.com/repos/massdriver-cloud/xo/releases/latest | jq -r '.assets[] | select(.name | contains("linux-amd64")) | .browser_download_url' | xargs curl -sSL -o xo.tar.gz && tar -xvf xo.tar.gz -C /tmp && mv /tmp/xo /usr/local/bin/ && rm xo.tar.gz && \
+    curl -sSL https://github.com/bridgecrewio/checkov/releases/download/${CHECKOV_VERSION}/checkov_linux_X86_64.zip -o checkov.zip && unzip checkov.zip && mv dist/checkov /usr/local/bin/ && rm -rf checkov.zip dist && \
+    curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ bookworm main"  > /etc/apt/sources.list.d/azure-cli.list && \
+    apt-get update && \
+    if [ "$AZURE_CLI_VERSION" = "latest" ]; then \
+        apt-get install -y --no-install-recommends azure-cli; \
     else \
-        apt install -y azure-cli=$AZ_CLI_VERSION*; \
+        apt-get install -y --no-install-recommends azure-cli=${AZURE_CLI_VERSION}*; \
     fi && \
     rm -rf /var/lib/apt/lists/*
 
@@ -29,23 +27,30 @@ FROM ${RUN_IMG}
 ARG USER
 ARG UID
 
-RUN apt update && apt install -y ca-certificates jq libicu72 && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates jq libicu76 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p -m 777 /massdriver
 
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --uid $UID \
-    $USER
-RUN chown -R $USER:$USER /massdriver
-USER $USER
+RUN useradd \
+    --create-home \
+    --shell /bin/bash \
+    --uid ${UID} \
+    ${USER} && \
+    chown -R ${USER}:${USER} /massdriver
 
-COPY --from=build /usr/local/bin/* /usr/local/bin/
+COPY --from=build /usr/local/bin/xo /usr/local/bin/xo
+COPY --from=build /usr/local/bin/checkov /usr/local/bin/checkov
 COPY --from=build /usr/bin/az /usr/bin/az
 COPY --from=build /opt/az /opt/az
-COPY entrypoint.sh /usr/local/bin/
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+USER ${USER}
+
+# Pre-install Bicep so `az stack` doesn't download it on first run
+RUN az bicep install
 
 ENV MASSDRIVER_PROVISIONER=bicep
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -euo pipefail
+# Unmatched globs expand to nothing instead of the literal pattern, so the
+# artifact_*.jq / resource_*.jq loops below simply skip when no files match.
+shopt -s nullglob
 
 # Define colors
 RED='\033[0;31m'
@@ -77,10 +80,12 @@ if [ -z "$azure_auth" ]; then
 fi
 
 # Extract fields from azure_service_principal and validate they are not empty
-azure_client_id=$(echo "$azure_auth" | jq -r '.data.client_id // empty')
-azure_client_secret=$(echo "$azure_auth" | jq -r '.data.client_secret // empty')
-azure_tenant_id=$(echo "$azure_auth" | jq -r '.data.tenant_id // empty')
-azure_subscription_id=$(echo "$azure_auth" | jq -r '.data.subscription_id // empty')
+# We expect the azure_service_principal to be a flat object with client_id, client_secret, tenant_id, and subscription_id fields
+# but we also check for the fields being nested under a "data" object (to support legacy formats)
+azure_client_id=$(echo "$azure_auth" | jq -r '.client_id // .data.client_id // empty')
+azure_client_secret=$(echo "$azure_auth" | jq -r '.client_secret // .data.client_secret // empty')
+azure_tenant_id=$(echo "$azure_auth" | jq -r '.tenant_id // .data.tenant_id // empty')
+azure_subscription_id=$(echo "$azure_auth" | jq -r '.subscription_id // .data.subscription_id // empty')
 
 for var in azure_client_id azure_client_secret azure_tenant_id; do
   if [ -z "${!var}" ]; then
@@ -89,7 +94,7 @@ for var in azure_client_id azure_client_secret azure_tenant_id; do
   fi
 done
 
-cd bundle/$MASSDRIVER_STEP_PATH
+cd "bundle/$MASSDRIVER_STEP_PATH"
 
 # Manipulate params/connections to fit Bicep format and write to file
 jq 'with_entries(.value |= {value: .})' "$connections_path" > connections.json
@@ -101,30 +106,29 @@ if ! az login --service-principal -u "$azure_client_id" -p "$azure_client_secret
   echo -e "${RED}Authentication failed. Please check the Azure credentials and refer to provisioner documentation.${NC}"
   exit 1
 fi
-az account set --subscription "$azure_subscription_id"
+
+# If subscription_id is provided, switch to it; otherwise fall back to the service
+# principal's default subscription.
+if [ -n "$azure_subscription_id" ]; then
+  az account set --subscription "$azure_subscription_id"
+fi
 echo -e "${GREEN}Authentication successful.${NC}\n"
 
 # Set flags for az stack commands
-flags=""
-flags+=" --action-on-unmanage $action_on_unmanage"
+flags=(--action-on-unmanage "$action_on_unmanage")
+create_flags=(--deny-settings-mode "$deny_settings_mode")
 
-create_flags=""
-create_flags+=" --deny-settings-mode $deny_settings_mode"
-
-show_flags=""
 case "$scope" in
   group)
     echo -e "Targeting resource group $resource_group\n"
-    flags+=" --resource-group $resource_group"
-    show_flags+=" --resource-group $resource_group"
-
+    flags+=(--resource-group "$resource_group")
     ;;
   sub)
-    echo -e "Targeting subscription $azure_subscription_id\n"
+    echo -e "Targeting subscription $(az account show --query id -o tsv)\n"
     if [ "$MASSDRIVER_DEPLOYMENT_ACTION" != "decommission" ]; then
-      create_flags+=" --location $location"
+      create_flags+=(--location "$location")
     fi
-    
+
     ;;
   *)
     echo -e "${RED}Error: Unsupported scope '$scope'. Expected 'group' or 'sub'.${NC}"
@@ -155,7 +159,7 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
         echo -e "${GREEN}Resource group $resource_group created.\n${NC}"
       else
         echo "Checking if resource group $resource_group exists..."
-        if az group exists --name "$resource_group" | grep -q "true"; then
+        if [ "$(az group exists --name "$resource_group")" = "true" ]; then
           echo "Resource group exists! Using existing resource group $resource_group"
         else
           echo -e "${RED}Error: Resource group $resource_group does not exist. If 'create_resource_group' is false, the resource group must already exist in Azure. To avoid this error, set 'create_resource_group' to 'true' in the provisioner configuration, or create the resource group $resource_group before provisioning.${NC}"
@@ -165,23 +169,27 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
     fi
 
     echo -e "Deploying stack $stack_name..."
-    create_output=$(az stack $scope create $create_flags $flags --name "$stack_name" --template-file template.bicep --parameters @params.json --parameters @connections.json)
-    echo "$create_output" | jq '.outputs // {} | with_entries(.value = .value.value)' | tee outputs.json
+    if ! az stack "$scope" create "${create_flags[@]}" "${flags[@]}" --name "$stack_name" --template-file template.bicep --parameters @params.json --parameters @connections.json > create_output.json; then
+      echo -e "${RED}Stack $stack_name deployment failed.${NC}"
+      cat create_output.json
+      exit 1
+    fi
+    jq '.outputs // {} | with_entries(.value = .value.value)' create_output.json | tee outputs.json
     echo -e "${GREEN}Stack $stack_name deployed successfully.\n${NC}"
 
-    jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > artifact_inputs.json
-    for artifact_file in artifact_*.jq; do
-      [ -f "$artifact_file" ] || break
-      field=$(echo "$artifact_file" | sed 's/^artifact_\(.*\).jq$/\1/')
-      echo "Creating artifact for field $field"
-      jq -f "$artifact_file" artifact_inputs.json | xo artifact publish -d "$field" -n "Artifact $field for $name_prefix" -f -
+    jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > resource_inputs.json
+    for resource_file in artifact_*.jq resource_*.jq; do
+      [ -f "$resource_file" ] || continue
+      field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
+      echo "Creating resource field $field"
+      jq -f "$resource_file" resource_inputs.json | xo resource publish -d "$field" -n "Resource $field for $name_prefix" -f -
     done
     ;;
 
   decommission)
 
     echo -e "Deleting stack $stack_name..."
-    az stack $scope delete $flags --name "$stack_name" --yes
+    az stack "$scope" delete "${flags[@]}" --name "$stack_name" --yes
     echo -e "${GREEN}Stack $stack_name deleted successfully.\n${NC}"
 
     if [ "$scope" = "group" ] && [ "$delete_resource_group" = "true" ]; then
@@ -190,11 +198,11 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
       echo -e "${GREEN}Resource group $resource_group deleted successfully.\n${NC}"
     fi
 
-    for artifact_file in artifact_*.jq; do
-      [ -f "$artifact_file" ] || break
-      field=$(echo "$artifact_file" | sed 's/^artifact_\(.*\).jq$/\1/')
-      echo "Deleting artifact for field $field"
-      xo artifact delete -d "$field"
+    for resource_file in artifact_*.jq resource_*.jq; do
+      [ -f "$resource_file" ] || continue
+      field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
+      echo "Deleting resource field $field"
+      xo resource delete -d "$field" || echo -e "${YELLOW}Warning: failed to delete resource for field $field. Continuing decommission.${NC}"
     done
     ;;
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,6 +94,11 @@ for var in azure_client_id azure_client_secret azure_tenant_id; do
   fi
 done
 
+# TODO: this can eventually be removed after MASSDRIVER_PACKAGE_NAME is fully deprecated
+if [ -z "${MASSDRIVER_INSTANCE_ID:-}" ]; then
+    export MASSDRIVER_INSTANCE_ID=$(echo "$MASSDRIVER_PACKAGE_NAME" | sed 's/-[a-z0-9]\{4\}$//')
+fi
+
 cd "bundle/$MASSDRIVER_STEP_PATH"
 
 # Manipulate params/connections to fit Bicep format and write to file
@@ -175,13 +180,13 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
       exit 1
     fi
     jq '.outputs // {} | with_entries(.value = .value.value)' create_output.json | tee outputs.json
-    echo -e "${GREEN}Stack $stack_name deployed successfully.\n${NC}"
+    echo -e "${GREEN}Stack $stack_name deployed successfully.${NC}"
 
     jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > resource_inputs.json
     for resource_file in artifact_*.jq resource_*.jq; do
       [ -f "$resource_file" ] || continue
       field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
-      echo "Creating resource field $field"
+      echo -e "\nCreating resource \"$MASSDRIVER_INSTANCE_ID-$field\" in Massdriver..."
       jq -f "$resource_file" resource_inputs.json | xo resource publish -d "$field" -n "Resource $field for $name_prefix" -f -
     done
     ;;
@@ -201,7 +206,7 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
     for resource_file in artifact_*.jq resource_*.jq; do
       [ -f "$resource_file" ] || continue
       field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
-      echo "Deleting resource field $field"
+      echo -e "\nDeleting resource \"$MASSDRIVER_INSTANCE_ID-$field\" from Massdriver..."
       xo resource delete -d "$field" || echo -e "${YELLOW}Warning: failed to delete resource for field $field. Continuing decommission.${NC}"
     done
     ;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,6 +52,7 @@ evaluate_checkov() {
 name_prefix=$(jq -r '.md_metadata.name_prefix' "$params_path")
 scope=$(jq -r '.scope // "group"' "$config_path")
 location=$(jq -r '.location // .region // "eastus"' "$config_path")
+show_output=$(jq_bool_default '.show_output' false "$config_path")
 action_on_unmanage=$(jq -r '.action_on_unmanage // "deleteAll"' "$config_path")
 deny_settings_mode=$(jq -r '.deny_settings_mode // "none"' "$config_path")
 
@@ -220,11 +221,14 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
 
     echo -e "Deploying stack $stack_name..."
     if ! az stack "$scope" create "${create_flags[@]}" "${flags[@]}" --name "$stack_name" --template-file template.bicep --parameters @params.json --parameters @connections.json > create_output.json; then
+      [ "$show_output" = "true" ] && cat create_output.json
       echo -e "${RED}Stack $stack_name deployment failed.${NC}"
-      cat create_output.json
       exit 1
     fi
-    jq '.outputs // {} | with_entries(.value = .value.value)' create_output.json | tee outputs.json
+    # The create output contains the deployment outputs nested within it, and may
+    # contain secrets, so it is printed only when show_output is enabled.
+    [ "$show_output" = "true" ] && cat create_output.json
+    jq '.outputs // {} | with_entries(.value = .value.value)' create_output.json > outputs.json
     echo -e "${GREEN}Stack $stack_name deployed successfully.${NC}"
 
     jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > resource_inputs.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,34 +65,93 @@ checkov_enabled=$(jq_bool_default '.checkov.enable' true "$config_path")
 checkov_quiet=$(jq_bool_default '.checkov.quiet' true "$config_path")
 checkov_halt_on_failure=$(jq_bool_default '.checkov.halt_on_failure' false "$config_path")
 
-# Extract auth
-# Try to get azure_service_principal from config.json, then fall back to connections.json
-azure_auth=$(jq -r '.azure_service_principal // empty' "$config_path" 2>/dev/null || true)
+# ---------------------------------------------------------------------------
+# Azure authentication
+#
+# Field resolution (config overlays the connection per-field; whichever single
+# connection is found is used, and config alone is fine if neither exists):
+#   1. config.json      .azure_authentication            (manual overlay, flat)
+#   2. connections.json .azure_authentication            (connection, flat)    } first
+#   3. connections.json .azure_service_principal.data    (legacy conn, .data)  } found
+#
+# Auth-method detection then runs on the resolved fields:
+#   1. secret present      -> static SP
+#   2. federated token env -> workload identity
+#   3. client_id           -> user-assigned MI
+#   4. else                -> system-assigned MI
+# subscription_id is independent of the method.
+# ---------------------------------------------------------------------------
 
-if [ -z "$azure_auth" ]; then
-  azure_auth=$(jq -r '.azure_service_principal // empty' "$connections_path" 2>/dev/null || true)
-fi
+# Overlay config.azure_authentication on top of whichever connection is found.
+auth=$(jq -s '
+    (.[1].azure_authentication // .[1].azure_service_principal.data // {}) as $conn
+  | (.[0].azure_authentication // {})                                   as $cfg
+  | $conn * $cfg
+' "$config_path" "$connections_path")
 
-# Check if azure_auth is still empty, and exit since we don't have auth info
-if [ -z "$azure_auth" ]; then
-  echo -e "${RED}Error: No Azure credentials found. Please refer to the provisioner documentation for specifying Azure credentials.${NC}"
+azure_client_id=$(echo "$auth"       | jq -r '.client_id // empty')
+azure_client_secret=$(echo "$auth"   | jq -r '.client_secret // empty')
+azure_tenant_id=$(echo "$auth"       | jq -r '.tenant_id // empty')
+azure_subscription_id=$(echo "$auth" | jq -r '.subscription_id // empty')
+
+# The workload-identity webhook injects these; let resolved config/connection win.
+azure_client_id="${azure_client_id:-${AZURE_CLIENT_ID:-}}"
+azure_tenant_id="${azure_tenant_id:-${AZURE_TENANT_ID:-}}"
+federated_token_file="${AZURE_FEDERATED_TOKEN_FILE:-}"
+
+auth_fail() {  # $1 = method, $2 = hint
+  echo -e "${RED}Azure authentication failed (${1}).${NC}" >&2
+  echo -e "${RED}${2}${NC}" >&2
   exit 1
+}
+
+if [ -n "$azure_client_secret" ]; then
+  echo "Authenticating to Azure with a service principal secret (client_id: ${azure_client_id:-<unset>})..."
+  missing=()
+  [ -z "$azure_client_id" ] && missing+=("client_id")
+  [ -z "$azure_tenant_id" ] && missing+=("tenant_id")
+  [ ${#missing[@]} -gt 0 ] && auth_fail "service principal secret" \
+    "client_secret was provided but these required fields are missing: ${missing[*]}."
+  az login --service-principal -u "$azure_client_id" -p "$azure_client_secret" -t "$azure_tenant_id" >/dev/null \
+    || auth_fail "service principal secret" \
+       "Verify client_id, client_secret, and tenant_id are correct and the secret has not expired."
+
+elif [ -n "$federated_token_file" ]; then
+  echo "Authenticating to Azure with workload identity (federated token)..."
+  missing=()
+  [ -z "$azure_client_id" ] && missing+=("client_id / AZURE_CLIENT_ID")
+  [ -z "$azure_tenant_id" ] && missing+=("tenant_id / AZURE_TENANT_ID")
+  [ ${#missing[@]} -gt 0 ] && auth_fail "workload identity" \
+    "AZURE_FEDERATED_TOKEN_FILE is set but these are missing: ${missing[*]}. Is the webhook injecting them / the service account annotated?"
+  [ -r "$federated_token_file" ] || auth_fail "workload identity" \
+    "Federated token file '$federated_token_file' is not readable."
+  az login --service-principal -u "$azure_client_id" -t "$azure_tenant_id" \
+    --federated-token "$(cat "$federated_token_file")" >/dev/null \
+    || auth_fail "workload identity" \
+       "The federated credential may not be configured on the app/identity for this cluster's OIDC issuer + service account."
+
+elif [ -n "$azure_client_id" ]; then
+  echo "Authenticating to Azure with a user-assigned managed identity (client_id: ${azure_client_id})..."
+  az login --identity --username "$azure_client_id" >/dev/null \
+    || auth_fail "user-assigned managed identity" \
+       "Is this identity assigned to the node, and is IMDS reachable from the pod?"
+
+else
+  echo "Authenticating to Azure with a system-assigned managed identity..."
+  echo -e "${YELLOW}Note: system-assigned managed identity is generally unavailable to Kubernetes pods. If this is an AKS pod, you almost certainly want workload identity instead.${NC}"
+  az login --identity >/dev/null \
+    || auth_fail "system-assigned managed identity" \
+       "No client_secret, no federated token, and no usable managed identity. For an AKS pod, configure workload identity."
 fi
 
-# Extract fields from azure_service_principal and validate they are not empty
-# We expect the azure_service_principal to be a flat object with client_id, client_secret, tenant_id, and subscription_id fields
-# but we also check for the fields being nested under a "data" object (to support legacy formats)
-azure_client_id=$(echo "$azure_auth" | jq -r '.client_id // .data.client_id // empty')
-azure_client_secret=$(echo "$azure_auth" | jq -r '.client_secret // .data.client_secret // empty')
-azure_tenant_id=$(echo "$azure_auth" | jq -r '.tenant_id // .data.tenant_id // empty')
-azure_subscription_id=$(echo "$azure_auth" | jq -r '.subscription_id // .data.subscription_id // empty')
+echo -e "${GREEN}Authenticated to Azure.${NC}\n"
 
-for var in azure_client_id azure_client_secret azure_tenant_id; do
-  if [ -z "${!var}" ]; then
-    echo -e "${RED}Error: Missing required field $var in azure_service_principal.${NC}"
-    exit 1
-  fi
-done
+# subscription_id: use if provided, otherwise the identity's default subscription.
+if [ -n "$azure_subscription_id" ]; then
+  az account set --subscription "$azure_subscription_id" \
+    || auth_fail "subscription selection" \
+       "Could not switch to subscription '$azure_subscription_id'. Does this identity have access to it?"
+fi
 
 # TODO: this can eventually be removed after MASSDRIVER_PACKAGE_NAME is fully deprecated
 if [ -z "${MASSDRIVER_INSTANCE_ID:-}" ]; then
@@ -104,20 +163,6 @@ cd "bundle/$MASSDRIVER_STEP_PATH"
 # Manipulate params/connections to fit Bicep format and write to file
 jq 'with_entries(.value |= {value: .})' "$connections_path" > connections.json
 jq 'with_entries(.value |= {value: .})' "$params_path" > params.json
-
-# Authenticate with Azure using the service principal
-echo "Authorizing to Azure using service principal..."
-if ! az login --service-principal -u "$azure_client_id" -p "$azure_client_secret" -t "$azure_tenant_id"; then
-  echo -e "${RED}Authentication failed. Please check the Azure credentials and refer to provisioner documentation.${NC}"
-  exit 1
-fi
-
-# If subscription_id is provided, switch to it; otherwise fall back to the service
-# principal's default subscription.
-if [ -n "$azure_subscription_id" ]; then
-  az account set --subscription "$azure_subscription_id"
-fi
-echo -e "${GREEN}Authentication successful.${NC}\n"
 
 # Set flags for az stack commands
 flags=(--action-on-unmanage "$action_on_unmanage")


### PR DESCRIPTION
## Summary

Updates the provisioner's toolchain versions, hardens the Docker image, and
makes a number of robustness/correctness improvements to `entrypoint.sh`.

## Dockerfile / image

- **Bump tool versions:** Azure CLI `2.75.0 → 2.86.0`, Checkov `3.2.268 → 3.2.530`.
- **Drop OPA** (`0.69.0`) entirely — it was installed but unused.
- **Base image:** `debian:12.7-slim → debian:13.5-slim` (and `libicu72 → libicu76`
  to match).
- **Fix latent ARG bug:** the build referenced `$AZ_CLI_VERSION` while the ARG was
  `AZURE_CLI_VERSION`, so the `else` branch never pinned a version. Now consistent.
- **Harden apt usage:** `apt-get … --no-install-recommends`, add `ca-certificates`,
  and switch the Microsoft repo to the `signed-by=/usr/share/keyrings/microsoft.gpg`
  pattern (no more deprecated `trusted.gpg.d`).
- **Copy only what we ship:** explicit `COPY` of `xo` and `checkov` instead of a
  `/usr/local/bin/*` wildcard (OPA is gone).
- **User creation:** `adduser → useradd` with a home dir and `/bin/bash` shell.
- **Pre-install Bicep** (`az bicep install`) at build time so `az stack` doesn't
  download it on first run.

## CI

- `docker_build_push.yaml`: matrix `azure_cli_version 2.81.0 → 2.86.0` to match
  the Dockerfile default.

## entrypoint.sh

- **Flexible Azure authentication:** the provisioner now auto-detects the auth
  method from the resolved credentials — static service principal secret, AKS
  **workload identity** (federated token), or **managed identity** — with clear
  per-method failure diagnostics.
- **Decoupled auth sourcing:** auth fields resolve from a `config.azure_authentication`
  overlay on top of an `azure_authentication` (or legacy `azure_service_principal`)
  connection, and `subscription_id` is now optional (falls back to the identity's
  default subscription).
- **`az` flags built as arrays** instead of space-joined strings, so values
  containing spaces can't be split into multiple arguments. Removed the unused
  `show_flags` variable.
- **`artifact_*.jq` and `resource_*.jq`** are both matched (via `nullglob` +
  `continue`, with the field name stripped from either prefix).
- **Non-fatal artifact/resource deletion on decommission:** a failed delete logs a
  warning and continues rather than aborting the teardown.
- **Surface deployment failures:** stack-create stdout goes to a file; on failure
  it's printed and the script exits non-zero.
- **Tighten `az group exists`** to a direct string compare instead of `grep -q`.